### PR TITLE
Add post for Deep Learning Indaba 2025

### DIFF
--- a/_posts/2025-08-12-gearing-up-for-dli-2025.md
+++ b/_posts/2025-08-12-gearing-up-for-dli-2025.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: "Gearing Up for Deep Learning Indaba 2025"
+date: 2025-08-12
+comments: true
+---
+
+| ![DLI 2024 in Senegal](https://github.com/KayO-GH/kayo-gh.github.io/assets/18174012/9ecbeda8-70c1-46f0-97b4-b1cb630a3ff8) | 
+|:--:| 
+| Photo credit: [David Adelani](https://dadelani.github.io/) |
+
+#### Welcome to Beautiful Kigali
+
+

--- a/_posts/2025-08-12-gearing-up-for-dli-2025.md
+++ b/_posts/2025-08-12-gearing-up-for-dli-2025.md
@@ -69,6 +69,7 @@ Now this was one of the most exciting events at last year's Indaba for me.
 
 Last year I made the rookie mistake of missing an announcement on available compute resources, and after competing using multiple Google Colab instances, I still managed to place a decent 5th in the Meta-GhanaNLP Translation Hackathon. We go again tihs year... so help me God 🙏🏾.
 
+<img width="662" height="441" alt="KayO-Tuning Meta LLMs for African Language Machine Translation" src="https://github.com/user-attachments/assets/7ba9511e-e915-489d-8d1c-4b1957fb8976" />
 
 
 #### 6. Poster Sessions
@@ -87,5 +88,7 @@ Kigali is a beautiful city, and there is even more beauty if you dare to venture
 ---
 That will be it from me for now. I'm looking forward to a beautiful week at this year's Indaba, and if you'll be attending and you happen to see me, do say hi! We can take a selfie 😉.
 
-See you in Kigali!
+See you in Kigali!  
+
+<img width="500" height="500" alt="Attending DLI 2025" src="https://github.com/user-attachments/assets/650e798e-32b2-48ea-b717-bcb319482b26" />
 

--- a/_posts/2025-08-12-gearing-up-for-dli-2025.md
+++ b/_posts/2025-08-12-gearing-up-for-dli-2025.md
@@ -5,10 +5,8 @@ date: 2025-08-12
 comments: true
 ---
 
-| ![DLI 2024 in Senegal](https://github.com/KayO-GH/kayo-gh.github.io/assets/18174012/9ecbeda8-70c1-46f0-97b4-b1cb630a3ff8) | 
+| ![DLI 2024 in Senegal](https://github.com/user-attachments/assets/f6729efd-e2ea-4c8f-9fde-f7df01fe6a20) | 
 |:--:| 
 | Photo credit: Amal Nammouchi on [Medium](https://medium.com/@amal.nammouchi12/the-hums-after-the-applause-reflecting-on-the-deep-learning-indaba-2024-66b0d3fbcf1a) |
 
 #### Xam Xamlé in Sunny Senegal!
-
-

--- a/_posts/2025-08-12-gearing-up-for-dli-2025.md
+++ b/_posts/2025-08-12-gearing-up-for-dli-2025.md
@@ -18,7 +18,22 @@ Last year's theme was Xam Xamlé (meaning "To gain knowledge and share it", in W
 
 Better blog posts have been written on the 2024 Indaba by very active participants in the community; like [this](https://deeplearningindaba.com/blog/2025/04/xam-xamle-our-latest-indaba-impact-report/), and [this](https://medium.com/@amal.nammouchi12/the-hums-after-the-applause-reflecting-on-the-deep-learning-indaba-2024-66b0d3fbcf1a), or maybe [this one](https://medium.com/@amal.nammouchi12/africlimate-ai-participation-at-the-deep-learning-indaba-2024-from-a-spark-to-a-community-469c5ae7b166?source=user_profile_page---------4-------------15305e64a0ec----------------------) or even [these](https://deeplearningindaba.com/blog/2024/08/). So all I will offer today is my two cents on what makes the DLI a great conference, and what you should look out for to make the most of the event.
 
-#### 1. Pracs (Now called Learnathons)
+### 🤝 Urunana – Hand in Hand for AI in Africa 🤝
+First, this year's theme: "Urunana".  Urunana is a beautiful Kinyarwanda word meaning "Hand in hand".
+
+From the horse's own mouth:  
+>“Urunana”, is a word that embodies the spirit of solidarity, cooperation, and shared responsibility. In many African traditions, “Urunana” (holding hands together) symbolizes the strength of community—just as we must come together to shape the future of AI on the continent.
+
+Beautiful, right? Now on to what I'd like to share with you:
+
+#### 1. The People are the Community
+It's not everyday that you meet top African professionals in the AI field all gathered in one room. It's also not everyday that you have Samy Bengio, Senior Director of AI and ML Research at Apple, join you at the dining table in shorts with his backpack, looking like everyone else. It's not everyday that you have people from Google, DeepMind, OpenAI and all other sorts of recognizable names in the same space, ready to answer your questions and provide mentorship. Not to mention the countless entrepreneurs and academics from different universities across the continent and the world at large.
+
+I'm saying you should come ready to absorb knowledge at every turn, make friends, make connections... it's literally the gathering of Africa's top AI talent. Period.
+
+By all means, don't hound people, but don't waste the opportunity of being in such a space either. And who knows... some companies might be hiring or giving out credits on tools you love.
+
+#### 2. Pracs (Now called Learnathons)
 Pracs (short for practicals) are a gem of the Deep Learning Indaba. Imagine having access to high-quality hands-on machine learning tutorials on state-of-the-art topics with functional base code; fully explained 🤯! That's an Indaba prac!
 
 "Where is this precious gem?" you ask. Freely available on the [DLI Github](https://github.com/deep-learning-indaba)! Here's a direct [link to the 2025 pracs](https://github.com/deep-learning-indaba/indaba-pracs-2025). You're welcome!
@@ -41,4 +56,36 @@ This year, we’re all about **depth, skills, and real progress** 📈:
 
 If you prefer the old formats, you can always revisit the [2024 prac](https://github.com/deep-learning-indaba/indaba-pracs-2024). That content is not totally out of date... yet. 🤭
 
-#### 2. 
+#### 3. Workshops & Mentoring Sessions
+This is me finding a way to circle back to the last two points and connect them. Workshops are usually just a little "higher level" than the pracs, and mentoring sessions are more structured so you can actually plan to meet that researcher you heard about. I don't have more to say... just take advantage of the opportunities and the wisdom of the people in the space.
+
+#### 4. Talks
+Maybe the talks should have ranked higher, because, yes, the ideas shared are great and will expand you knowledge and perspective within the industry... however, many of those will be recorded. You can always come back to them online later, or read the associated paper, if there's one.
+
+IMO, most of the really valuable knowledge transfer happens within the hallways and around the snack tables.
+
+#### 5. Hackathon(s)
+Now this was one of the most exciting events at last year's Indaba for me.
+
+Last year I made the rookie mistake of missing an announcement on available compute resources, and after competing using multiple Google Colab instances, I still managed to place a decent 5th in the Meta-GhanaNLP Translation Hackathon. We go again tihs year... so help me God 🙏🏾.
+
+
+
+#### 6. Poster Sessions
+You hardly see plain walls when you gather academics and researchers in one space. No, we cover the walls with our posters, because you will read our research. 😅
+
+Don't miss the poster sessions. Not every great idea makes it to the stage, but you can always scope them out during the poster sessions!
+
+#### 7. The Ideathon
+This is the event for the people who's interests are in the practical applications of ML/AI to solve real world issues. Ideathons are structured to forge collaboration and offer support from the community to people who want to solve real issues using modern technology.
+
+Here are [a few past solutions](https://www.youtube.com/playlist?list=PLICxY_yQeGYnf5tLXXqcfJ5AqTaVg3bX7), and I highly recommend this any enterprising attendees of the Indaba!
+
+#### 8. Finally... Explore
+Kigali is a beautiful city, and there is even more beauty if you dare to venture out and explore Rwanda further. I'll leave that hype work to [Visit Rwanda](https://visitrwanda.com/).
+
+---
+That will be it from me for now. I'm looking forward to a beautiful week at this year's Indaba, and if you'll be attending and you happen to see me, do say hi! We can take a selfie 😉.
+
+See you in Kigali!
+

--- a/_posts/2025-08-12-gearing-up-for-dli-2025.md
+++ b/_posts/2025-08-12-gearing-up-for-dli-2025.md
@@ -10,3 +10,35 @@ comments: true
 | Photo credit: Amal Nammouchi on [Medium](https://medium.com/@amal.nammouchi12/the-hums-after-the-applause-reflecting-on-the-deep-learning-indaba-2024-66b0d3fbcf1a) |
 
 #### Xam Xamlé in Sunny Senegal!
+> I'm somewhere in this picture... yes, all the way at the back (as tall people usually are), in front of the pillar to the left.
+
+Anyway, it's been a year already since the Deep Learning Indaba in Senegal, and another edition is upon us in beautiful Rwanda 🇷🇼, my second home.
+
+Last year's theme was Xam Xamlé (meaning "To gain knowledge and share it", in Wolof, I think), which truly embodies the DLI's culture of democratizing knowledge in the African AI space.
+
+Better blog posts have been written on the 2024 Indaba by very active participants in the community; like [this](https://deeplearningindaba.com/blog/2025/04/xam-xamle-our-latest-indaba-impact-report/), and [this](https://medium.com/@amal.nammouchi12/the-hums-after-the-applause-reflecting-on-the-deep-learning-indaba-2024-66b0d3fbcf1a), or maybe [this one](https://medium.com/@amal.nammouchi12/africlimate-ai-participation-at-the-deep-learning-indaba-2024-from-a-spark-to-a-community-469c5ae7b166?source=user_profile_page---------4-------------15305e64a0ec----------------------) or even [these](https://deeplearningindaba.com/blog/2024/08/). So all I will offer today is my two cents on what makes the DLI a great conference, and what you should look out for to make the most of the event.
+
+#### 1. Pracs (Now called Learnathons)
+Pracs (short for practicals) are a gem of the Deep Learning Indaba. Imagine having access to high-quality hands-on machine learning tutorials on state-of-the-art topics with functional base code; fully explained 🤯! That's an Indaba prac!
+
+"Where is this precious gem?" you ask. Freely available on the [DLI Github](https://github.com/deep-learning-indaba)! Here's a direct [link to the 2025 pracs](https://github.com/deep-learning-indaba/indaba-pracs-2025). You're welcome!
+
+If you're making it to the Indaba, install all the necessary packages and libraries in advance so you don't waste valuable learning time with the instructors running `pip installs` on potentially unstable internet.
+
+Here's a final note. Pracs have been rebranded as learnathons this year, and will be extended beyond the single onsite sessions. Here's the official memo in the `readme` for this year's prac:  
+In past years, we had **one-off** practicals covering many topics — exciting, but often rushed ⏳.  
+This year, we’re all about **depth, skills, and real progress** 📈:
+
+> - 🗓 **Multi-session tracks — now called Learnathons** 📚🔥:  
+>   - **Part 1** → Live, **onsite** during Indaba 🎤  
+>   - **Parts 2–4** → **Online** after Indaba 🖥, so you can practise, grow your skills, and gain confidence with the topic over several weeks.
+> 
+> - 🏆 **Certificates & prizes**: Attend **80%+** of your Learnathon → earn an **Indaba Certificate** 📜 + possible **sponsor prizes** 🎁.  
+> 
+> - 🌍 **Community meetups**: Exploring **physical locations** in some countries for the online sessions (**TBA**) 📍.  
+> 
+> - 🌐 **English & French** for the onsite practicals 🗣.
+
+If you prefer the old formats, you can always revisit the [2024 prac](https://github.com/deep-learning-indaba/indaba-pracs-2024). That content is not totally out of date... yet. 🤭
+
+#### 2. 

--- a/_posts/2025-08-12-gearing-up-for-dli-2025.md
+++ b/_posts/2025-08-12-gearing-up-for-dli-2025.md
@@ -7,8 +7,8 @@ comments: true
 
 | ![DLI 2024 in Senegal](https://github.com/KayO-GH/kayo-gh.github.io/assets/18174012/9ecbeda8-70c1-46f0-97b4-b1cb630a3ff8) | 
 |:--:| 
-| Photo credit: [David Adelani](https://dadelani.github.io/) |
+| Photo credit: Amal Nammouchi on [Medium](https://medium.com/@amal.nammouchi12/the-hums-after-the-applause-reflecting-on-the-deep-learning-indaba-2024-66b0d3fbcf1a) |
 
-#### Welcome to Beautiful Kigali
+#### Xam Xamlé in Sunny Senegal!
 
 


### PR DESCRIPTION
Create and update a blog post detailing the upcoming Deep Learning Indaba 2025, including themes, events, and practical sessions. The post emphasizes community engagement and opportunities for learning and collaboration.